### PR TITLE
Talk to an agent: add SSE option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "n8n-nodes-dust",
-	"version": "0.1.69",
+	"version": "0.1.70",
 	"description": "Dust.tt node for n8n",
 	"keywords": [
 		"n8n-community-node-package"


### PR DESCRIPTION
## Description

The goal of this PR is to add an option to the Dust node > Operation: Talk to an agent, to listen to events SSE endpoint until receiving the agent_message_done event or until timeout is reached, to then retrieve the last Agent message and to return it, with the events.

The code adds 2 options in the Talk to an agent operation:
<img width="385" height="605" alt="Screenshot 2025-11-20 at 11 26 37" src="https://github.com/user-attachments/assets/a4b70a84-6ca2-44c0-bce2-b768a561c8fd" />

The first option changes the request made to create the conversation and post the message, to a blocking: false mode.
If this option is enabled, the request won't wait for the Agent response. The code will instead call the /events endpoint in SSE, to listen to the conversation events until receiving the "agent_message_done" event, or until the timeout defined in the second option (or by default = 300 seconds) is reached.
Once the event is received, the code will retrieve all the messages from the agent having the node message ID as parentMessageId, it will concatenate them and return it in the node response. It will also add the "events" arrays in the node response, containing the data json of each events received during the event listening.

On top of this, I edited the way to join the messages to avoid joining empty messages, to avoid responses looking like "\n\n\n\nHello World\n". Unfortunately, the code inside Dust can still generate this in one single agent message, so we can't fully avoid it.
Avoiding joining empty messages will output "No message returned" in the case there are only empty agent messages in the conversation.

## Tests

I built the node and started a local instance of n8n with it:
```
npm run build \
export N8N_CUSTOM_EXTENSIONS="$HOME/n8n-extensions" \
rsync -a --delete --exclude node_modules --exclude .git /Users/m.bellou/Dev/dust-n8n-node/ "$N8N_CUSTOM_EXTENSIONS/n8n-nodes-dust/" \
npx n8n
```
In the local n8n instance, I created a Dust node, used the Talk to agent operation, and called an agent that used to answer "\n\n\n\n" because it usually takes 10-20 minutes to run.
With this setup, I enabled the SSE option + timeout at 3000 seconds, and the node now returns (in my case after 409379 ms) the agent message and an array of events (including user_message_new, agent_message_new, conversation_title and agent_mesasage_done).

With the same node, I configured the node with a 10 second timeout, and the node fails after 10491 ms with the error message "This operation was aborted".

With the same node, I disabled the SSE option and got "No message returned" after ~180 seconds.

With the same node, I disabled the SSE option and configured a timeout of 10 seconds. The node behaves normally, and the timeout is not applied.

## Risk

The code contains a `while (true)` loop but is wrapped in an AbortController with a timeout that is always set.
I couldn't test the case where the SSE connexion is unexpectedly interrupted. The code is supposed to produce an exception that will be caught in the try/catch and should produce an error in n8n node.

## Deploy plan

Simply merge the code and make a new release in npm, available for n8n clients.