### PR TITLE
Address comments

### DIFF
--- a/credentials/DustApi.credentials.ts
+++ b/credentials/DustApi.credentials.ts
@@ -59,9 +59,6 @@ export class DustApi implements ICredentialType {
 		request: {
 			url: '={{$credentials.region === "EU" ? "https://eu.dust.tt" : "https://dust.tt"}}/api/v1/w/{{$credentials.workspaceId}}/assistant/agent_configurations',
 			method: 'GET',
-			headers: {
-				Authorization: '=Bearer {{$credentials.apiKey}}',
-			},
 		},
 	};
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "n8n-nodes-dust",
-	"version": "0.1.69",
+	"version": "0.1.70",
 	"description": "Dust.tt node for n8n",
 	"keywords": [
 		"n8n-community-node-package"


### PR DESCRIPTION
## Description
Addresses feedback from n8n community node review to improve code quality and follow n8n best practices. Removes redundant authentication headers from credential test (since `httpRequestWithAuthentication` already handles this), restructures the node with a resource-based organization (Agent/Document), and improves error handling by adding `continueOnFail()` support and removing unnecessary try-catch blocks.

## Risk
Low. Changes primarily improve code organization and error handling patterns. The credential test fix ensures we're not sending duplicate Authorization headers.
